### PR TITLE
Remove cursorless-send-state-timer

### DIFF
--- a/command-client.el
+++ b/command-client.el
@@ -144,9 +144,8 @@
        (setq-local transient-mark-mode (cons 'only transient-mark-mode))))
 
     ;; This keeps various things up-to-date, eg. hl-line-mode.
-    (run-hooks 'post-command-hook)
-    ;; Update state for cursorless to read.
-    (cursorless-send-state-callback)))
+    ;; This also runs our send-state function.
+    (run-hooks 'post-command-hook)))
 
 ;; ping, state, stateWithContents, applyPrimaryEditorState (?),
 ;; command, cursorless, pid


### PR DESCRIPTION
@rntz Would you mind taking a look at this? I think it's functionally equivalent and just reduces the global var count by 1.

Edit: I should clarify, without this PR I get all sorts of "Timer already activated" errors.
