### PR TITLE
Avoid errors on creating a new empty file

### DIFF
--- a/cursorless-state.el
+++ b/cursorless-state.el
@@ -92,7 +92,7 @@
     :path (or (buffer-file-name) :null)
     :temporaryFilePath (cursorless-temporary-file-path)
     :firstVisibleLine (line-number-at-pos (window-start))
-    :lastVisibleLine  (line-number-at-pos (- (window-end) 1))
+    :lastVisibleLine  (line-number-at-pos (window-end))
     ;; where the cursors are. in emacs, only one cursor, so a singleton vector.
     ;; note that cursorless wants line/column, not offset.
     ;; TODO: if transient-mark-mode is enabled, represent the whole selection.


### PR DESCRIPTION
It's possible for (window-start) and (window-end) to be the same. In particular they can both be 1 for new empty files which makes
line-number-at-pos fail.

@rntz Was there a particular reason you were subtracting 1 here? If so we can just change the argument to line-number-at-pos to be `(max (window-start) (- (window-end) 1))`. 